### PR TITLE
トップ カラム幅調整

### DIFF
--- a/scss/project/_front-page.scss
+++ b/scss/project/_front-page.scss
@@ -26,13 +26,16 @@
     .wp-block-column {
       margin-right: 24px;
       margin-left: 24px;
+      max-width: 420px;
 
       @include sp {
         flex-basis: calc(50% - 48px);
       }
-
-      @include pc {
-        max-width: 420px;      }
+    }
+    .p-front_with {
+      .wp-block-column {
+        max-width: 606px;
+      }
     }
     .p-cnt--outline {
 


### PR DESCRIPTION
固定ページ 「WordCamp Osaka 2019へようこそ」編集
写真と「with_」を並べているカラムブロックに ```p-front_with``` class 付与してcss振り分けてます。